### PR TITLE
Adding support to definition bucket/1 that use `{file, scope}` as argument

### DIFF
--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -76,6 +76,12 @@ defmodule Waffle.Storage.Google.CloudStorage do
   def bucket(definition), do: Util.var(definition.bucket())
 
   @doc """
+  Returns the bucket for file uploads from scope.
+  """
+  @spec bucket(Types.definition, Types.meta) :: String.t
+  def bucket(definition, meta), do: Util.var(definition.bucket(meta))
+
+  @doc """
   Returns the storage directory **within a bucket** to store the file under.
   """
   @spec storage_dir(Types.definition, Types.version, Types.meta) :: String.t

--- a/test/support/definitions.ex
+++ b/test/support/definitions.ex
@@ -17,6 +17,8 @@ end
 
 defmodule DummyDefinition do
   use DummyDefBase
+
+  def bucket({_file, _scope}), do: bucket()
 end
 
 defmodule DummyDefinitionInvalidBucket do


### PR DESCRIPTION
this PR adds support for feature https://github.com/elixir-waffle/waffle/pull/31