### PR TITLE
Allow custom token fetching defined in config

### DIFF
--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -65,8 +65,10 @@ defmodule Waffle.Storage.Google.CloudStorage do
   """
   @spec conn(String.t) :: Tesla.Env.client
   def conn(scope \\ @full_control_scope) do
-    {:ok, token} = Goth.Token.for_scope(scope)
-    Connection.new(token.token)
+    token_store = Application.get_env(:waffle, :token_fetcher, Waffle.Storage.Google.Token.DefaultFetcher)
+
+    token_store.get_token(scope)
+    |> Connection.new()
   end
 
   @doc """

--- a/lib/waffle/storage/google/token/default_fetcher.ex
+++ b/lib/waffle/storage/google/token/default_fetcher.ex
@@ -1,0 +1,9 @@
+defmodule Waffle.Storage.Google.Token.DefaultFetcher do
+  @behaviour Waffle.Storage.Google.Token.Fetcher
+
+  @impl Waffle.Storage.Google.Token.Fetcher
+  def get_token(scope) do
+    {:ok, token} = Goth.Token.for_scope(scope)
+    token.token
+  end
+end

--- a/lib/waffle/storage/google/token/fetcher.ex
+++ b/lib/waffle/storage/google/token/fetcher.ex
@@ -1,0 +1,3 @@
+defmodule Waffle.Storage.Google.Token.Fetcher do
+  @callback get_token(binary) :: binary
+end


### PR DESCRIPTION
Mirrors martide/arc_gcs#97.

I have multiple sets of credentials in Goth, which means I have to call for_scope in a different way. I thought it would be good to allow people full control over the token generation when needed, so I set up a new configuration option that lets you define your own behavior in a module. This also defines a behaviour that the token module should implement.